### PR TITLE
Fix Capitalization bug

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@
 const lowerCase = require('./lower-case')
 const specials = require('./specials')
 
-const regex = /(?:(?:(\s?(?:^|[.\(\)!?;:"-])\s*)(\w))|(\w))(\w*[’']*\w*)/g
+const regex = /(?:(?:(\s?(?:^|[.\(\)!?;:"-])\s*)(\w))|(\w))(\w*[’'àèìòùÀÈÌÒÙáéíóúýÁÉÍÓÚÝâêîôûÂÊÎÔÛãñõÃÑÕäëïöüÿÄËÏÖÜŸçÇßØøÅåÆæœ]*\w*)/g
 
 const convertToRegExp = specials => specials.map(s => [new RegExp(`\\b${s}\\b`, 'gi'), s])
 

--- a/test/index.js
+++ b/test/index.js
@@ -77,3 +77,17 @@ test("should not capitalize word in adjacent parens", t => {
   to = "Cat(s) can Be a Pain"
   t.is(title(from), to)
 })
+
+test("should accept special unicode character 'ñ'" ,t => {
+  const from = "diseño"
+  const to = "Diseño"
+
+  t.is(title(from), to)
+})
+
+test("should accept accent mark" ,t => {
+  const from = "fernández"
+  const to = "Fernández"
+
+  t.is(title(from), to)
+})


### PR DESCRIPTION
fixes issue #33

Example:
title('diseño')
// Diseño
title('fernández')
// Fernández