### PR TITLE
Capitalize the last word

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,9 @@ function parseMatch(match) {
 }
 
 module.exports = (str, options = {}) => {
-  str = str.toLowerCase().replace(regex, (m, lead = '', forced, lower, rest) => {
+  str = str.toLowerCase().replace(regex, (m, lead = '', forced, lower, rest, offset, string) => {
+    const isLastWord = m.length + offset >= string.length;
+
     const parsedMatch = parseMatch(m)
     if (!parsedMatch) {
       return m
@@ -31,7 +33,7 @@ module.exports = (str, options = {}) => {
     if (!forced) {
       const fullLower = lower + rest
 
-      if (lowerCase.has(fullLower)) {
+      if (lowerCase.has(fullLower) && !isLastWord) {
         return parsedMatch
       }
     }

--- a/test/index.js
+++ b/test/index.js
@@ -77,3 +77,19 @@ test("should not capitalize word in adjacent parens", t => {
   to = "Cat(s) can Be a Pain"
   t.is(title(from), to)
 })
+
+test("should capitalize the last word regardless of syntax", t => {
+  let from, to;
+
+  from = "there and beyond"
+  to = "There and Beyond"
+  t.is(title(from), to)
+
+  from = "be careful what you wish for"
+  to = "Be Careful What You Wish For"
+  t.is(title(from), to)
+
+  from = "XYZ: what is it good for"
+  to = "XYZ: What Is It Good For"
+  t.is(title(from, { special: ["XYZ"] }), to)
+})


### PR DESCRIPTION
Chicago Manual of Style dictates that the last word of titles should be capitalized regardless of its syntax.
This change will skip lowercasing it if the word is the last word.