### PR TITLE
Fix handling of international characters

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,8 @@
 const lowerCase = require('./lower-case')
 const specials = require('./specials')
 
-const regex = /(?:(?:(\s?(?:^|[.\(\)!?;:"-])\s*)(\w))|(\w))(\w*[’']*\w*)/g
+const word = "[^\\s'’\\(\\)!?;:\"-]"
+const regex = new RegExp(`(?:(?:(\\s?(?:^|[.\\(\\)!?;:"-])\\s*)(${word}))|(${word}))(${word}*[’']*${word}*)`, "g")
 
 const convertToRegExp = specials => specials.map(s => [new RegExp(`\\b${s}\\b`, 'gi'), s])
 

--- a/test/index.js
+++ b/test/index.js
@@ -106,4 +106,12 @@ test("supports international characters", t => {
   from = "forhandlingsmøde"
   to = "Forhandlingsmøde"
   t.is(title(from), to)
+
+  from = "đội"
+  to = "Đội"
+  t.is(title(from), to)
+
+  from = "tuyển"
+  to = "Tuyển"
+  t.is(title(from), to)
 })

--- a/test/index.js
+++ b/test/index.js
@@ -105,4 +105,5 @@ test("supports international characters", t => {
 
   from = "forhandlingsmøde"
   to = "Forhandlingsmøde"
+  t.is(title(from), to)
 })

--- a/test/index.js
+++ b/test/index.js
@@ -93,3 +93,16 @@ test("should capitalize the last word regardless of syntax", t => {
   to = "XYZ: What Is It Good For"
   t.is(title(from, { special: ["XYZ"] }), to)
 })
+
+test("supports international characters", t => {
+  let from = "çeşme city"
+  let to = "Çeşme City"
+  t.is(title(from), to)
+
+  from = "la niña esta aquí"
+  to = "La Niña Esta Aquí"
+  t.is(title(from), to)
+
+  from = "forhandlingsmøde"
+  to = "Forhandlingsmøde"
+})


### PR DESCRIPTION
The character class `\w` only matches ASCII characters. By replacing it with a more permissive negated set, international (unicode) characters are handled correctly.

Added tests for these international characters. All these tests fail without this fix.

Fixes #33

Let me know if there's any changes I can do to help this get merged. 