### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,7 @@ function parseMatch(match) {
   // test first character
   if (/\s/.test(firstCharacter)) {
     // if whitespace - trim and return
-    return match.substr(1)
+    return match.slice(1)
   }
   if (/[\(\)]/.test(firstCharacter)) {
     // if parens - this shouldn't be replaced


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.