### PR TITLE
X handle has changed

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -68,5 +68,5 @@ After that, you can use the `title` command everywhere.
 
 ## Authors
 
-- Leo Lamprecht ([@notquiteleo](https://twitter.com/notquiteleo))
+- Leo Lamprecht ([@leo](https://x.com/leo))
 - Josh Junon ([@Qix-](https://github.com/Qix-))


### PR DESCRIPTION
Twitter was renamed to X and my X handle changed from `@notquiteleo` to `@leo`.

This change replaces the previous broken link with the new working link.