### PR TITLE
Add "vs." to lowercase prepositions

### DIFF
--- a/src/lower-case.ts
+++ b/src/lower-case.ts
@@ -81,6 +81,7 @@ const prepositions = [
   'upon',
   'versus',
   'via',
+  'vs',
   'with',
   'within',
   'without'


### PR DESCRIPTION
Also worth noting that CMOS 18 no longer lowercases prepositions longer than four characters, so those should be removed.

https://titlecaseconverter.com/blog/cmos-18-changes/